### PR TITLE
Fix for two errors encountered in the tutorial

### DIFF
--- a/diskmap/diskmap.py
+++ b/diskmap/diskmap.py
@@ -90,16 +90,16 @@ class DiskMap:
         if self.image.shape[0] != self.image.shape[1]:
             raise ValueError("The dimensions of the image should have the same size.")
         
-        # if type(self.image[0,0]) == np.float32:
-        #     warnings.warn(
-        #         "The FITS file data is of type np.float32, this will be converted to np.float64"
-        #     )
-        #     self.image = self.image.astype(np.float64)
+        if type(self.image[0,0]) == np.float32:
+            warnings.warn(
+                "The FITS file data is of type np.float32, this will be converted to np.float64"
+            )
+            self.image = self.image.astype(np.float64)
             
-        # elif type(self.image[0,0]) != np.float64:
-        #     raise ValueError(
-        #         "The FITS file data should be either of type np.float32 or np.float64"
-        #     )
+        elif type(self.image[0,0]) != np.float64:
+            raise ValueError(
+                "The FITS file data should be either of type np.float32 or np.float64"
+            )
 
         if image_type not in ["polarized", "total"]:
             raise ValueError(

--- a/diskmap/diskmap.py
+++ b/diskmap/diskmap.py
@@ -35,8 +35,8 @@ class DiskMap:
         ----------
         fitsfile : str, np.ndarray
             Name of the FITS file with the scattered light image.
-            Alternatively, a 2D ``numpy`` array with the image can
             be directly provided.
+            Alternatively, a 2D ``numpy`` array with the image can
         pixscale : float
             Pixel scale of the image (arcsec per pixel).
         inclination : float
@@ -83,18 +83,23 @@ class DiskMap:
             self.image = self.image[
                 0,
             ]
-            
-        if type(self.image[0,0]) == np.float32:
-            warnings.warn(
-                "The FITS file data is of type np.float32, this will be converted to np.float64"
-            )
-            self.image = self.image.astype(np.float64)
 
         elif self.image.ndim != 2:
             raise ValueError("DiskMap requires a 2D image.")
 
         if self.image.shape[0] != self.image.shape[1]:
             raise ValueError("The dimensions of the image should have the same size.")
+        
+        if type(self.image[0,0]) == np.float32:
+            warnings.warn(
+                "The FITS file data is of type np.float32, this will be converted to np.float64"
+            )
+            self.image = self.image.astype(np.float64)
+            
+        elif type(self.image[0,0]) != np.float64:
+            raise ValueError(
+                "The FITS file data should be either of type np.float32 or np.float64"
+            )
 
         if image_type not in ["polarized", "total"]:
             raise ValueError(

--- a/diskmap/diskmap.py
+++ b/diskmap/diskmap.py
@@ -90,13 +90,13 @@ class DiskMap:
         if self.image.shape[0] != self.image.shape[1]:
             raise ValueError("The dimensions of the image should have the same size.")
         
-        if type(self.image[0,0]) == np.float32:
+        if self.image.dtype == np.float32:
             warnings.warn(
                 "The FITS file data is of type np.float32, this will be converted to np.float64"
             )
             self.image = self.image.astype(np.float64)
             
-        elif type(self.image[0,0]) != np.float64:
+        elif self.image.dtype != np.float64:
             raise ValueError(
                 "The FITS file data should be either of type np.float32 or np.float64"
             )

--- a/diskmap/diskmap.py
+++ b/diskmap/diskmap.py
@@ -90,16 +90,16 @@ class DiskMap:
         if self.image.shape[0] != self.image.shape[1]:
             raise ValueError("The dimensions of the image should have the same size.")
         
-        if type(self.image[0,0]) == np.float32:
-            warnings.warn(
-                "The FITS file data is of type np.float32, this will be converted to np.float64"
-            )
-            self.image = self.image.astype(np.float64)
+        # if type(self.image[0,0]) == np.float32:
+        #     warnings.warn(
+        #         "The FITS file data is of type np.float32, this will be converted to np.float64"
+        #     )
+        #     self.image = self.image.astype(np.float64)
             
-        elif type(self.image[0,0]) != np.float64:
-            raise ValueError(
-                "The FITS file data should be either of type np.float32 or np.float64"
-            )
+        # elif type(self.image[0,0]) != np.float64:
+        #     raise ValueError(
+        #         "The FITS file data should be either of type np.float32 or np.float64"
+        #     )
 
         if image_type not in ["polarized", "total"]:
             raise ValueError(
@@ -594,7 +594,7 @@ class DiskMap:
                         self.im_scaled[i, j] = mask_planet[3] * self.image[i, j]
 
     @typechecked
-    def total_intensity(self, pol_max: 1.0) -> None:
+    def total_intensity(self, pol_max: float = 1.0) -> None:
         """
         Function for estimating the (stellar irradiation corrected)
         total intensity image when ``fitsfile`` contains a polarized

--- a/diskmap/diskmap.py
+++ b/diskmap/diskmap.py
@@ -35,8 +35,8 @@ class DiskMap:
         ----------
         fitsfile : str, np.ndarray
             Name of the FITS file with the scattered light image.
-            be directly provided.
             Alternatively, a 2D ``numpy`` array with the image can
+            be directly provided.
         pixscale : float
             Pixel scale of the image (arcsec per pixel).
         inclination : float

--- a/diskmap/diskmap.py
+++ b/diskmap/diskmap.py
@@ -83,6 +83,12 @@ class DiskMap:
             self.image = self.image[
                 0,
             ]
+            
+        if type(self.image[0,0]) == np.float32:
+            warnings.warn(
+                "The FITS file data is of type np.float32, this will be converted to np.float64"
+            )
+            self.image = self.image.astype(np.float64)
 
         elif self.image.ndim != 2:
             raise ValueError("DiskMap requires a 2D image.")

--- a/diskmap/diskmap.py
+++ b/diskmap/diskmap.py
@@ -90,15 +90,15 @@ class DiskMap:
         if self.image.shape[0] != self.image.shape[1]:
             raise ValueError("The dimensions of the image should have the same size.")
         
-        if self.image.dtype == np.float32:
+        if self.image.dtype == np.float32 or self.image.dtype == np.dtype('>f4'):
             warnings.warn(
-                "The FITS file data is of type np.float32, this will be converted to np.float64"
+                "The FITS file data is of type float32, this will be converted to float64"
             )
             self.image = self.image.astype(np.float64)
             
-        elif self.image.dtype != np.float64:
+        if self.image.dtype != np.float64 and self.image.dtype != np.dtype('>f8'):
             raise ValueError(
-                "The FITS file data should be either of type np.float32 or np.float64"
+                f"The FITS file data should be either of type float32 or float64"
             )
 
         if image_type not in ["polarized", "total"]:


### PR DESCRIPTION
Fixed the problem described in #2:

Added a check in the __init__ method to see if the image array contains data of type `np.float32`. If it is, then it is converted to `np.float64`.

Also added a check to see if the data is anything _except_ `np.float32` or `np.float64`. In this case, instead of a later uninformative error caused by the enforced type-hinting, an exception is raised here.

This could easily be modified to convert additional data types to `np.float64` such as `np.float16` to allow for additional flexibility, but I have just implemented the smallest sensible change.

Fixed also the problem described in #4 using the proposed fix described in that thread.