### PR TITLE
Added support for arbitrary height function for deprojection

### DIFF
--- a/diskmap/diskmap.py
+++ b/diskmap/diskmap.py
@@ -146,7 +146,7 @@ class DiskMap:
         power_law: Tuple[float, float, float],
         radius: Tuple[float, float, int] = (1.0, 500.0, 100),
         surface: str = "power-law",
-        height_func: Optional[Callable] = None,
+        height_func: Optional[Callable[[np.ndarray],np.ndarray]] = None,
         filename: Optional[str] = None,
     ) -> None:
         """
@@ -178,7 +178,7 @@ class DiskMap:
         height_func : callable, None
             Function that returns the height of the scattering surface
             as a function of radius. The radii and returned height must
-            be in au. 
+            be in au. Only used if surface='function'.
         filename : str, None
             Filename which contains the radius in au (first column) and
             the height of the disk surface in au (second column).
@@ -220,10 +220,7 @@ class DiskMap:
             disk_radius = np.linspace(radius[0], radius[1], radius[2])
 
             # disk height (au)
-            try:
-                disk_height = height_func(disk_radius)
-            except TypeError:
-                raise ValueError("height_func must take only one argument, the radius in au.")
+            disk_height = height_func(disk_radius)
 
             # opening angle (rad)
             disk_opening = np.arctan2(disk_height, disk_radius)


### PR DESCRIPTION
Just a small update to add support for a user-specified height function instead of either a power-law or tabulated. Obviously, one could always tabulate data from their chosen parameterisation, but this is a little more convenient and I thought it may be useful for someone else as well at some point :)

I added also appropriate changes to the docstring and type-checking, as well as a few checks that the user is specifying the right thing. The tests are also passing locally on my machine.